### PR TITLE
feat(form-address): prevent address overwrite when viewing existing r…

### DIFF
--- a/src/features/client/components/client-form-manager.tsx
+++ b/src/features/client/components/client-form-manager.tsx
@@ -182,7 +182,7 @@ export const ClientFormManager = ({defaultValue, mode, loadingModal,setLoadingMo
                 />
             </div>
             {/* Sessão endereço */}
-            <FormAddress methods={methods} setLoading={setLoadingLocal} mode={mode}/>
+            <FormAddress methods={methods} setLoading={setLoadingLocal} mode={mode} shouldIgnoreInitialZipCodeSearch={true}/>
             
             {/* Sessão endereço cobrança */}
             {isBillingAddressValue === "não" &&

--- a/src/features/suppliers/components/suppliers-form-manager.tsx
+++ b/src/features/suppliers/components/suppliers-form-manager.tsx
@@ -29,7 +29,7 @@ interface SuppliersFormManagerProps{
 }
 
 export const SuppliersFormManager = ({defaultValue, mode, loadingModal, setLoadingModal, status, setMode, viewRequestId, obervationRequest, setStatusLocal}:SuppliersFormManagerProps) => {
-    
+    console.log(defaultValue)
     if(loadingModal){
         return <LoadingModal/> 
     }
@@ -152,7 +152,7 @@ export const SuppliersFormManager = ({defaultValue, mode, loadingModal, setLoadi
             {/* SubTitulo Endereço */}
             <SubTitleForm title="Endereço"  styleLine="border-t-3 border-dashed border-strong/10 mt-4" icon={ZipCodeIcon}/>
             {/* Sessão endereço */}
-            <FormAddress methods={methods} setLoading={setLoadingLocal} mode={mode}/>
+            <FormAddress methods={methods} setLoading={setLoadingLocal} mode={mode} shouldIgnoreInitialZipCodeSearch={true}/>
 
             {/* Sessão para informar o motivo que está negando a solicitação */}
             {mode === "denied" && (


### PR DESCRIPTION
…equest Previously, when opening a saved request, the address form would make a new CEP API call even if address data already existed in the database. If the API response was missing some fields (e.g., provided manually by the user), those values were overwritten and visually lost, even though they were saved. This behavior has been fixed to prioritize existing data and avoid unnecessary overwrites.